### PR TITLE
Only reload when url contains path of changed file

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ module.exports["plugin"] = function (opts, bs) {
 
         debug('Responding to file change event', data.namespace);
 
-        requestNew(opts);
+        requestNew(opts, data);
     }
 
     function pluginEvent () {
@@ -214,7 +214,7 @@ module.exports["plugin"] = function (opts, bs) {
      * @param {String} url
      * @param {Object} opts - plugin options
      */
-    function requestNew (opts) {
+    function requestNew (opts, data) {
 
         // Remove any
         var valid = bs.io.of(bs.options.getIn(["socket", "namespace"])).sockets.map(function (client) {
@@ -230,26 +230,29 @@ module.exports["plugin"] = function (opts, bs) {
                 return;
             }
 
-            debug("requesting %s", url);
-
-            request(getRequestOptions(url), function (error, response, body) {
-
-                if (!error && response.statusCode == 200) {
-
-                    var tasks = htmlInjector.process(body, htmlInjector.cache[url], url, opts);
-
-                    if (tasks.length) {
-                        debug("%s tasks returned", tasks.length);
-                        tasks.forEach(function (task) {
-                            debug("Task: TAG: %s, INDEX: %s", task.tagName, task.index);
-                            clients.emit(config.CLIENT_EVENT, task);
-                        });
-                    } else {
-                        debug("0 tasks returned, reloading instead");
-                        clients.emit("browser:reload");
+            if (!data || url.indexOf(data.path) !== -1) {
+                
+                debug("requesting %s", url);
+    
+                request(getRequestOptions(url), function (error, response, body) {
+    
+                    if (!error && response.statusCode == 200) {
+    
+                        var tasks = htmlInjector.process(body, htmlInjector.cache[url], url, opts);
+    
+                        if (tasks.length) {
+                            debug("%s tasks returned", tasks.length);
+                            tasks.forEach(function (task) {
+                                debug("Task: TAG: %s, INDEX: %s", task.tagName, task.index);
+                                clients.emit(config.CLIENT_EVENT, task);
+                            });
+                        } else {
+                            debug("0 tasks returned, reloading instead");
+                            clients.emit("browser:reload");
+                        }
                     }
-                }
-            });
+                });
+            }
         });
     }
 };


### PR DESCRIPTION
I was seeing the injection, but also getting a reload because multiple html files are changing, so adding a check seems to take care of this problem. 

I only figured out how to make this work for this config style though:

```
bs.use(htmlInjector, {
    files: ['./**/*.html']
  });
```

The logs below have my own debugging messages:

Before:

```
[BS] [HTML Injector] Responding to file change event {"event":"change","path":"docs/index.html","namespace":"HTML Injector"}
[BS] [HTML Injector] Cache items: 1
[BS] [HTML Injector] requesting http://localhost:3000/docs/maintenance/index.html
[BS] [HTML Injector] Responding to file change event {"event":"change","path":"docs/maintenance/index.html","namespace":"HTML Injector"}
[BS] [HTML Injector] Cache items: 1
[BS] [HTML Injector] requesting http://localhost:3000/docs/maintenance/index.html
[BS] [HTML Injector] 1 tasks returned
[BS] [HTML Injector] Task: TAG: DIV, INDEX: 25
[BS] [HTML Injector] 0 tasks returned, reloading instead

```

After: 

```
[BS] [HTML Injector] Responding to file change event {"event":"change","path":"docs/index.html","namespace":"HTML Injector"}
[BS] [HTML Injector] Cache items: 1
[BS] [HTML Injector] requesting http://localhost:3000/docs/maintenance/index.html
[BS] [HTML Injector] Responding to file change event {"event":"change","path":"docs/maintenance/index.html","namespace":"HTML Injector"}
[BS] [HTML Injector] Cache items: 1
[BS] [HTML Injector] requesting http://localhost:3000/docs/maintenance/index.html
[BS] [HTML Injector] 1 tasks returned
[BS] [HTML Injector] Task: TAG: DIV, INDEX: 25
```

Perhaps this could be an option. Thoughts?
